### PR TITLE
Fixed UI lock up when leaving multiplayer match

### DIFF
--- a/src/main/java/com/mycompany/seniorproject/games/tictactoe/TicTacToeGameController.java
+++ b/src/main/java/com/mycompany/seniorproject/games/tictactoe/TicTacToeGameController.java
@@ -683,6 +683,11 @@ public class TicTacToeGameController {
      */
     @FXML
     private void onQuitMouseClick() throws IOException {
+        if (connection != null){
+            connection.sendPacket("Rematch Declined END MESSAGE");
+            connection.closeConnection();
+            connection = null;
+        }
         exitGame();
 
     }
@@ -783,6 +788,12 @@ public class TicTacToeGameController {
                     winnerRectangleMultiplayerRematch.setVisible(false);
                     winnerCircleMultiplayerRematch.setVisible(true);
                 }
+            }else if ( response.contains("Rematch Declined")){
+                try {
+                    exitGame();
+                } catch (IOException ex) {
+                    Logger.getLogger(TicTacToeGameController.class.getName()).log(Level.SEVERE, null, ex);
+                }
             }
         });
         new Thread(task).start();
@@ -793,7 +804,7 @@ public class TicTacToeGameController {
      */
     @FXML
     private void onAcceptRematchClick() {
-        // Junk string to feed the rematch listening thread
+        // Junk string to feed the listenForRematch thread
         connection.sendPacket(" END MESSAGE");
         // actual message
         connection.sendPacket("Rematch Accepted END MESSAGE");
@@ -807,7 +818,7 @@ public class TicTacToeGameController {
      */
     @FXML
     private void onDeclineRematchClick() throws IOException {
-        // Junk string to feed the rematch listening thread
+        // Junk string to feed the listenForRematch thread
         connection.sendPacket(" END MESSAGE");
         // actual message
         connection.sendPacket("Rematch Declined END MESSAGE");

--- a/src/main/java/com/mycompany/seniorproject/games/tictactoe/TicTacToeNetworkMatchSetUpController.java
+++ b/src/main/java/com/mycompany/seniorproject/games/tictactoe/TicTacToeNetworkMatchSetUpController.java
@@ -124,6 +124,7 @@ public class TicTacToeNetworkMatchSetUpController implements Initializable {
         Task task = new Task<Void>() {
             @Override
             public Void call() throws IOException {
+                buttonHost.setDisable(true);
                 connection = new PeerToPeer();
                 connection.startHost(port);
                 Platform.runLater(() -> {
@@ -142,7 +143,14 @@ public class TicTacToeNetworkMatchSetUpController implements Initializable {
                 return null;
             }
         };
-        task.setOnSucceeded(taskFinishEvent -> System.out.println("Connected: \n" + connection.toString()));
+        task.setOnSucceeded(taskFinishEvent -> {
+                buttonHost.setDisable(false);
+                System.out.println("Connected: \n" + connection.toString());
+        });
+        task.setOnFailed(taskFinishEvent -> {
+                buttonHost.setDisable(false);
+                System.out.println("Connection failed");
+        });
         new Thread(task).start();
     }
 


### PR DESCRIPTION
Both users are now correctly sent back to main menu if either chooses to leave the end game screen without a rematch.